### PR TITLE
Add visible([value]).

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -71,9 +71,9 @@ function module_resolve(name) {
     if (this._runtime._builtin._scope.has(name)) {
       variable.import(name, this._runtime._builtin);
     } else if (name === "invalidation") {
-      variable.define(variable_invalidate);
+      variable.define(name, variable_invalidate);
     } else if (name === "visible") {
-      variable.define(variable_visible);
+      variable.define(name, variable_visible);
     } else {
       this._scope.set(variable._name = name, variable);
     }

--- a/src/module.js
+++ b/src/module.js
@@ -1,6 +1,6 @@
 import {forEach} from "./array";
 import identity from "./identity";
-import {variable_invalidate, variable_visible} from "./runtime";
+import {variable_invalidation, variable_visibility} from "./runtime";
 import Variable, {TYPE_IMPLICIT, TYPE_NORMAL} from "./variable";
 
 var none = new Map;
@@ -71,9 +71,9 @@ function module_resolve(name) {
     if (this._runtime._builtin._scope.has(name)) {
       variable.import(name, this._runtime._builtin);
     } else if (name === "invalidation") {
-      variable.define(name, variable_invalidate);
+      variable.define(name, variable_invalidation);
     } else if (name === "visible") {
-      variable.define(name, variable_visible);
+      variable.define(name, variable_visibility);
     } else {
       this._scope.set(variable._name = name, variable);
     }

--- a/src/module.js
+++ b/src/module.js
@@ -1,5 +1,6 @@
 import {forEach} from "./array";
 import identity from "./identity";
+import {variable_invalidate, variable_visible} from "./runtime";
 import Variable, {TYPE_IMPLICIT, TYPE_NORMAL} from "./variable";
 
 var none = new Map;
@@ -69,6 +70,10 @@ function module_resolve(name) {
     variable = new Variable(TYPE_IMPLICIT, this);
     if (this._runtime._builtin._scope.has(name)) {
       variable.import(name, this._runtime._builtin);
+    } else if (name === "invalidation") {
+      variable.define(variable_invalidate);
+    } else if (name === "visible") {
+      variable.define(variable_visible);
     } else {
       this._scope.set(variable._name = name, variable);
     }

--- a/src/module.js
+++ b/src/module.js
@@ -72,7 +72,7 @@ function module_resolve(name) {
       variable.import(name, this._runtime._builtin);
     } else if (name === "invalidation") {
       variable.define(name, variable_invalidation);
-    } else if (name === "visible") {
+    } else if (name === "visibility") {
       variable.define(name, variable_visibility);
     } else {
       this._scope.set(variable._name = name, variable);

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -1,5 +1,4 @@
 import {RuntimeError} from "./errors";
-import constant from "./constant";
 import generatorish from "./generatorish";
 import load from "./load";
 import Module from "./module";
@@ -133,13 +132,13 @@ function variable_invalidator(variable) {
 }
 
 function variable_intersector(element) {
-  return constant(function(value) {
+  return function(value) {
     return new Promise(resolve => {
       const observed = ([entry]) => entry.isIntersecting && (observer.disconnect(), resolve(value));
       const observer = new IntersectionObserver(observed);
       observer.observe(element);
     });
-  });
+  };
 }
 
 function variable_compute(variable) {

--- a/src/variable.js
+++ b/src/variable.js
@@ -9,6 +9,7 @@ export var TYPE_IMPLICIT = 2; // created on reference
 export var TYPE_DUPLICATE = 3; // created on duplicate definition
 
 export var variable_invalidate = {};
+export var variable_visible = {};
 export var no_observer = {};
 
 export default function Variable(type, module, observer) {
@@ -54,9 +55,11 @@ function variable_detach(variable) {
 }
 
 function variable_resolve(name) {
-  return name === "invalidation"
-      ? new Variable(TYPE_IMPLICIT, this._module).define(variable_invalidate)
-      : this._module._resolve(name);
+  switch (name) {
+    case "invalidation": return new Variable(TYPE_IMPLICIT, this._module).define(variable_invalidate);
+    case "visible": return new Variable(TYPE_IMPLICIT, this._module).define(variable_visible);
+    default: return this._module._resolve(name);
+  }
 }
 
 function variable_undefined() {


### PR DESCRIPTION
The **visible** function provides a convenient mechanism for pausing execution of a cell that is offscreen. For example, this cell increments continuously:

```js
{
  for (let i = 0; true; ++i) {
    yield i;
  }
}
```

By using **visible**, a cell can increment only if it is currently visible:

```js
{
  for (let i = 0; true; ++i) {
    yield visible(i);
  }
}
```

This is functionally equivalent to:

```js
{
  for (let i = 0; true; ++i) {
    await visible();
    yield i;
  }
}
```

TODO:

- [ ] This relies on IntersectionObserver; we should implement a fallback for browsers that don’t support IntersectionObserver. ~~(It might also be nice to optimize the implementation so that it doesn’t require a separate IntersectionObserver per node.)~~ Unfortunately, this requires communication up to the parent frame… making this quite difficult.

- [x] This assumes that *variable*._observer is an instance of [Inspector](https://github.com/observablehq/notebook-inspector/blob/master/README.md#Inspector), or at the least, that *variable*._observer._node is the *variable*’s associated DOM element. If that’s not the case, then visible(*value*) should behave like Promise.resolve(*value*) (so that this works with imports).

- [x] ~~Possibly we don’t need **visible** at all: we could automatically skip the evaluation of cells that are not visible, as long as none of their transitive outputs are visible.~~ Not going to do this.

- [ ] Rename to visibility?