### PR TITLE
Update test examples

### DIFF
--- a/test/dom.html
+++ b/test/dom.html
@@ -2,13 +2,13 @@
 <body class="O--body">
 <div id="fooview"></div>
 <div id="foo"></div>
-<script src="/dist/notebook-runtime.js"></script>
-<script>
+<script type=module>
+import {Runtime, Inspector, Library} from "/dist/notebook-runtime.js";
 
-var runtime = new Runtime(),
+var runtime = new Runtime(new Library),
     module = runtime.module();
 
-module.variable("#fooview").define("viewof foo", ["DOM"], DOM => DOM.range());
-module.variable("#foo").define("foo", ["Generators", "viewof foo"], (Generators, input) => Generators.input(input));
+module.variable(new Inspector(document.querySelector("#fooview"))).define("viewof foo", ["DOM"], DOM => DOM.range());
+module.variable(new Inspector(document.querySelector("#foo"))).define("foo", ["Generators", "viewof foo"], (Generators, input) => Generators.input(input));
 
 </script>

--- a/test/hello-world.html
+++ b/test/hello-world.html
@@ -3,14 +3,14 @@
 <p>What is your name?
 <div id="name"></div>
 <div id="hello"></div>
-<script src="/dist/notebook-runtime.js"></script>
-<script>
+<script type=module>
+import {Runtime, Inspector, Library} from "/dist/notebook-runtime.js";
 
-var runtime = new Runtime(),
+var runtime = new Runtime(new Library),
     module = runtime.module();
 
-module.variable("#name").define("viewof name", ["DOM"], DOM => DOM.input());
+module.variable(new Inspector(document.querySelector("#name"))).define("viewof name", ["DOM"], DOM => DOM.input());
 module.variable().define("name", ["Generators", "viewof name"], (Generators, view) => Generators.input(view));
-module.variable("#hello").define(["name"], name => `Hello, ${name || "anonymous"}!`);
+module.variable(new Inspector(document.querySelector("#hello"))).define(["name"], name => `Hello, ${name || "anonymous"}!`);
 
 </script>

--- a/test/require.html
+++ b/test/require.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <body class="O--body">
 <div id="foo"></div>
-<script src="/dist/notebook-runtime.js"></script>
-<script>
+<script type=module>
+import {Runtime, Inspector, Library} from "/dist/notebook-runtime.js";
 
-var runtime = new Runtime(),
+var runtime = new Runtime(new Library),
     module = runtime.module();
 
 module.variable().define("d3", ["require"], require => require("d3-array"));
-module.variable("#foo").define(["d3"], d3 => d3.range(100));
+module.variable(new Inspector(document.querySelector("#foo"))).define(["d3"], d3 => d3.range(100));
 
 </script>


### PR DESCRIPTION
Fixes #123 - updates the examples under /test/ to match the current API and to import from the ES6 build of the library.