### PR TITLE
 Allow implicit globals.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,10 +2,7 @@
   "extends": "eslint:recommended",
   "parserOptions": {
     "sourceType": "module",
-    "ecmaVersion": 8,
-    "ecmaFeatures": {
-      "experimentalObjectRestSpread": true
-    }
+    "ecmaVersion": 8
   },
   "env": {
     "browser": true,

--- a/src/module.js
+++ b/src/module.js
@@ -1,4 +1,5 @@
 import {forEach} from "./array";
+import constant from "./constant";
 import identity from "./identity";
 import {variable_invalidation, variable_visibility} from "./runtime";
 import Variable, {TYPE_IMPLICIT, TYPE_NORMAL} from "./variable";
@@ -65,13 +66,13 @@ function module_copy(injectByAlias, injectModule, map) {
 }
 
 function module_resolve(name) {
-  var variable = this._scope.get(name);
+  var variable = this._scope.get(name), value;
   if (!variable)  {
     variable = new Variable(TYPE_IMPLICIT, this);
     if (this._runtime._builtin._scope.has(name)) {
       variable.import(name, this._runtime._builtin);
-    } else if (this._runtime._globals.has(name)) {
-      variable.define(name, window_global(name));
+    } else if ((value = this._runtime._global(name)) !== undefined) {
+      variable.define(name, constant(value));
     } else if (name === "invalidation") {
       variable.define(name, variable_invalidation);
     } else if (name === "visibility") {
@@ -85,10 +86,4 @@ function module_resolve(name) {
 
 function variable_name(variable) {
   return variable._name;
-}
-
-function window_global(name) {
-  return function() {
-    return window[name];
-  };
 }

--- a/src/module.js
+++ b/src/module.js
@@ -70,6 +70,8 @@ function module_resolve(name) {
     variable = new Variable(TYPE_IMPLICIT, this);
     if (this._runtime._builtin._scope.has(name)) {
       variable.import(name, this._runtime._builtin);
+    } else if (this._runtime._globals.has(name)) {
+      variable.define(name, window_global(name));
     } else if (name === "invalidation") {
       variable.define(name, variable_invalidation);
     } else if (name === "visibility") {
@@ -83,4 +85,10 @@ function module_resolve(name) {
 
 function variable_name(variable) {
   return variable._name;
+}
+
+function window_global(name) {
+  return function() {
+    return window[name];
+  };
 }

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -8,14 +8,14 @@ import Variable, {TYPE_IMPLICIT, no_observer} from "./variable";
 export var variable_invalidation = {};
 export var variable_visibility = {};
 
-export default function Runtime(builtins, globals) {
+export default function Runtime(builtins, global = noop) {
   var builtin = this.module();
   Object.defineProperties(this, {
     _dirty: {value: new Set},
     _updates: {value: new Set},
     _computing: {value: null, writable: true},
     _builtin: {value: builtin},
-    _globals: {value: new Set(globals)}
+    _global: {value: global}
   });
   if (builtins) for (var name in builtins) {
     (new Variable(TYPE_IMPLICIT, builtin)).define(name, [], builtins[name]);

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -8,7 +8,7 @@ import Variable, {TYPE_IMPLICIT, no_observer} from "./variable";
 export var variable_invalidation = {};
 export var variable_visibility = {};
 
-export default function Runtime(builtins, global = noop) {
+export default function Runtime(builtins, global = window_global) {
   var builtin = this.module();
   Object.defineProperties(this, {
     _dirty: {value: new Set},
@@ -247,4 +247,8 @@ function variable_reachable(variable) {
     output._outputs.forEach(outputs.add, outputs);
   }
   return false;
+}
+
+function window_global(name) {
+  return window[name];
 }

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -8,13 +8,14 @@ import Variable, {TYPE_IMPLICIT, no_observer} from "./variable";
 export var variable_invalidation = {};
 export var variable_visibility = {};
 
-export default function Runtime(builtins) {
+export default function Runtime(builtins, globals) {
   var builtin = this.module();
   Object.defineProperties(this, {
     _dirty: {value: new Set},
     _updates: {value: new Set},
     _computing: {value: null, writable: true},
-    _builtin: {value: builtin}
+    _builtin: {value: builtin},
+    _globals: {value: new Set(globals)}
   });
   if (builtins) for (var name in builtins) {
     (new Variable(TYPE_IMPLICIT, builtin)).define(name, [], builtins[name]);

--- a/test/load-test.js
+++ b/test/load-test.js
@@ -1,7 +1,7 @@
 import load from "../src/load";
 import tape from "./tape";
 
-tape("basic notebook as module loading", {html: "<div id=foo />"}, async test => {
+tape("basic notebook as module loading", async test => {
   let result = null;
   load({
     id: "notebook@1",
@@ -23,7 +23,7 @@ tape("basic notebook as module loading", {html: "<div id=foo />"}, async test =>
   test.equals(result, 101);
 });
 
-tape("notebooks as modules with variables depending on other variables", {html: "<div id=foo />"}, async test => {
+tape("notebooks as modules with variables depending on other variables", async test => {
   let result = null;
   load({
     id: "notebook@1",
@@ -50,7 +50,7 @@ tape("notebooks as modules with variables depending on other variables", {html: 
   test.equals(result, 202);
 });
 
-tape("notebooks as modules with imports", {html: "<div id=foo />"}, async test => {
+tape("notebooks as modules with imports", async test => {
   let result = null;
   load({
     id: "notebook@1",
@@ -87,7 +87,7 @@ tape("notebooks as modules with imports", {html: "<div id=foo />"}, async test =
   test.equals(result, 202);
 });
 
-tape("Rejects with an error when trying to import from a nonexistent module", {html: "<div id=foo />"}, async test => {
+tape("Rejects with an error when trying to import from a nonexistent module", async test => {
   const failures = [];
   load({
     id: "notebook@1",
@@ -119,7 +119,7 @@ tape("Rejects with an error when trying to import from a nonexistent module", {h
   ]);
 });
 
-tape("notebook as modules with builtins", {html: "<div id=foo /><div id=bar />"}, async test => {
+tape("notebook as modules with builtins", async test => {
   let result = null;
   load({
     id: "notebook@1",
@@ -144,7 +144,7 @@ tape("notebook as modules with builtins", {html: "<div id=foo /><div id=bar />"}
   test.equals(result, 84);
 });
 
-tape("notebook with the default standard library", {html: "<div id=foo /><div id=bar />"}, async test => {
+tape("notebook with the default standard library", async test => {
   let result = null;
   load({
     id: "notebook@1",

--- a/test/runtime/builtins-test.js
+++ b/test/runtime/builtins-test.js
@@ -2,35 +2,35 @@ import {Runtime} from "../../src/";
 import tape from "../tape";
 import valueof from "../variable/valueof";
 
-tape("new Runtime(builtins) allows builtins to be defined as promises", {html: "<div id=foo />"}, async test => {
+tape("new Runtime(builtins) allows builtins to be defined as promises", async test => {
   const runtime = new Runtime({color: Promise.resolve("red")});
   const main = runtime.module();
-  const foo = main.variable("#foo").define(null, ["color"], color => color);
+  const foo = main.variable(true).define(null, ["color"], color => color);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: "red"});
 });
 
-tape("new Runtime(builtins) allows builtins to be defined as functions", {html: "<div id=foo />"}, async test => {
+tape("new Runtime(builtins) allows builtins to be defined as functions", async test => {
   const runtime = new Runtime({color: () => "red"});
   const main = runtime.module();
-  const foo = main.variable("#foo").define(null, ["color"], color => color);
+  const foo = main.variable(true).define(null, ["color"], color => color);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: "red"});
 });
 
-tape("new Runtime(builtins) allows builtins to be defined as async functions", {html: "<div id=foo />"}, async test => {
+tape("new Runtime(builtins) allows builtins to be defined as async functions", async test => {
   const runtime = new Runtime({color: async () => "red"});
   const main = runtime.module();
-  const foo = main.variable("#foo").define(null, ["color"], color => color);
+  const foo = main.variable(true).define(null, ["color"], color => color);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: "red"});
 });
 
-tape("new Runtime(builtins) allows builtins to be defined as generators", {html: "<div id=foo />"}, async test => {
+tape("new Runtime(builtins) allows builtins to be defined as generators", async test => {
   let i = 0;
   const runtime = new Runtime({i: function*() { while (i < 3) yield ++i; }});
   const main = runtime.module();
-  const foo = main.variable("#foo").define(null, ["i"], i => i);
+  const foo = main.variable(true).define(null, ["i"], i => i);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 1});
   await new Promise(setImmediate);

--- a/test/tape.js
+++ b/test/tape.js
@@ -16,9 +16,9 @@ tape.only = function(description, options, run) {
   return _.only(description, wrap(options, run));
 };
 
-function wrap({html = ""} = {}, run) {
+function wrap(options, run) {
   return async test => {
-    const window = new JSDOM(html).window;
+    const window = new JSDOM().window;
     const document = window.document;
     global.requestAnimationFrame = setImmediate;
     global.window = window;

--- a/test/variable/define-test.js
+++ b/test/variable/define-test.js
@@ -2,77 +2,77 @@ import {Runtime} from "../../src/";
 import tape from "../tape";
 import valueof from "./valueof";
 
-tape("variable.define(name, inputs, definition) can define a variable", {html: "<div id=foo />"}, async test => {
+tape("variable.define(name, inputs, definition) can define a variable", async test => {
   const runtime = new Runtime();
   const module = runtime.module();
-  const foo = module.variable("#foo").define("foo", [], () => 42);
+  const foo = module.variable(true).define("foo", [], () => 42);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 42});
 });
 
-tape("variable.define(inputs, function) can define an anonymous variable", {html: "<div id=foo />"}, async test => {
+tape("variable.define(inputs, function) can define an anonymous variable", async test => {
   const runtime = new Runtime();
   const module = runtime.module();
-  const foo = module.variable("#foo").define([], () => 42);
+  const foo = module.variable(true).define([], () => 42);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 42});
 });
 
-tape("variable.define(name, function) can define a named variable", {html: "<div id=foo /><div id=bar />"}, async test => {
+tape("variable.define(name, function) can define a named variable", async test => {
   const runtime = new Runtime();
   const module = runtime.module();
-  const foo = module.variable("#foo").define("foo", () => 42);
-  const bar = module.variable("#bar").define("bar", ["foo"], foo => foo);
+  const foo = module.variable(true).define("foo", () => 42);
+  const bar = module.variable(true).define("bar", ["foo"], foo => foo);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 42});
   test.deepEqual(await valueof(bar), {value: 42});
 });
 
-tape("variable.define(function) can define an anonymous variable", {html: "<div id=foo />"}, async test => {
+tape("variable.define(function) can define an anonymous variable", async test => {
   const runtime = new Runtime();
   const module = runtime.module();
-  const foo = module.variable("#foo").define(() => 42);
+  const foo = module.variable(true).define(() => 42);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 42});
 });
 
-tape("variable.define(null, inputs, value) can define an anonymous constant", {html: "<div id=foo />"}, async test => {
+tape("variable.define(null, inputs, value) can define an anonymous constant", async test => {
   const runtime = new Runtime();
   const module = runtime.module();
-  const foo = module.variable("#foo").define(null, [], 42);
+  const foo = module.variable(true).define(null, [], 42);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 42});
 });
 
-tape("variable.define(inputs, value) can define an anonymous constant", {html: "<div id=foo />"}, async test => {
+tape("variable.define(inputs, value) can define an anonymous constant", async test => {
   const runtime = new Runtime();
   const module = runtime.module();
-  const foo = module.variable("#foo").define([], 42);
+  const foo = module.variable(true).define([], 42);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 42});
 });
 
-tape("variable.define(null, value) can define an anonymous constant", {html: "<div id=foo />"}, async test => {
+tape("variable.define(null, value) can define an anonymous constant", async test => {
   const runtime = new Runtime();
   const module = runtime.module();
-  const foo = module.variable("#foo").define(null, 42);
+  const foo = module.variable(true).define(null, 42);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 42});
 });
 
-tape("variable.define(value) can define an anonymous constant", {html: "<div id=foo />"}, async test => {
+tape("variable.define(value) can define an anonymous constant", async test => {
   const runtime = new Runtime();
   const module = runtime.module();
-  const foo = module.variable("#foo").define(42);
+  const foo = module.variable(true).define(42);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 42});
 });
 
-tape("variable.define detects missing inputs", {html: "<div id=foo /><div id=bar />"}, async test => {
+tape("variable.define detects missing inputs", async test => {
   const runtime = new Runtime();
   const module = runtime.module();
-  const foo = module.variable("#foo");
-  const bar = module.variable("#bar").define("bar", ["foo"], foo => foo);
+  const foo = module.variable(true);
+  const bar = module.variable(true).define("bar", ["foo"], foo => foo);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: undefined});
   test.deepEqual(await valueof(bar), {error: "RuntimeError: foo is not defined"});
@@ -82,11 +82,11 @@ tape("variable.define detects missing inputs", {html: "<div id=foo /><div id=bar
   test.deepEqual(await valueof(bar), {value: 1});
 });
 
-tape("variable.define detects duplicate names", {html: "<div id=foo /><div id=bar />"}, async test => {
+tape("variable.define detects duplicate names", async test => {
   const runtime = new Runtime();
   const module = runtime.module();
-  const foo = module.variable("#foo").define("foo", 1);
-  const bar = module.variable("#bar").define("foo", 2);
+  const foo = module.variable(true).define("foo", 1);
+  const bar = module.variable(true).define("foo", 2);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {error: "RuntimeError: foo is defined more than once"});
   test.deepEqual(await valueof(bar), {error: "RuntimeError: foo is defined more than once"});
@@ -96,14 +96,14 @@ tape("variable.define detects duplicate names", {html: "<div id=foo /><div id=ba
   test.deepEqual(await valueof(bar), {value: 2});
 });
 
-tape("variable.define recomputes reachability as expected", {html: "<div id=foo />"}, async test => {
+tape("variable.define recomputes reachability as expected", async test => {
   const runtime = new Runtime();
   const main = runtime.module();
   const module = runtime.module();
   const quux = module.define("quux", [], () => 42);
   const baz = module.define("baz", ["quux"], quux => `baz-${quux}`);
   const bar = module.define("bar", ["quux"], quux => `bar-${quux}`);
-  const foo = main.variable("#foo").define("foo", ["bar", "baz", "quux"], (bar, baz, quux) => [bar, baz, quux]);
+  const foo = main.variable(true).define("foo", ["bar", "baz", "quux"], (bar, baz, quux) => [bar, baz, quux]);
   main.variable().import("bar", module);
   main.variable().import("baz", module);
   main.variable().import("quux", module);
@@ -122,7 +122,7 @@ tape("variable.define recomputes reachability as expected", {html: "<div id=foo 
   test.deepEqual(await valueof(foo), {value: "foo"});
 });
 
-tape("variable.define correctly detects reachability for unreachable cycles", {html: "<div id=foo />"}, async test => {
+tape("variable.define correctly detects reachability for unreachable cycles", async test => {
   let returned = false;
   const runtime = new Runtime();
   const main = runtime.module();
@@ -141,7 +141,7 @@ tape("variable.define correctly detects reachability for unreachable cycles", {h
   test.deepEqual(await valueof(quux), {value: undefined});
   test.deepEqual(await valueof(zapp), {value: undefined});
   main.variable().import("bar", module);
-  const foo = main.variable("#foo").define("foo", ["bar"], bar => bar);
+  const foo = main.variable(true).define("foo", ["bar"], bar => bar);
   await new Promise(setImmediate);
   test.equal(foo._reachable, true);
   test.equal(bar._reachable, true);
@@ -168,13 +168,13 @@ tape("variable.define correctly detects reachability for unreachable cycles", {h
   test.equal(returned, false); // Generator is never finalized because it has never run.
 });
 
-tape("variable.define terminates previously reachable generators", {html: "<div id=foo />"}, async test => {
+tape("variable.define terminates previously reachable generators", async test => {
   let returned = false;
   const runtime = new Runtime();
   const main = runtime.module();
   const module = runtime.module();
   const bar = module.define("bar", [], function*() { try { while (true) yield 1; } finally { returned = true; }});
-  const foo = main.variable("#foo").define("foo", ["bar"], bar => bar);
+  const foo = main.variable(true).define("foo", ["bar"], bar => bar);
   main.variable().import("bar", module);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 1});
@@ -185,14 +185,14 @@ tape("variable.define terminates previously reachable generators", {html: "<div 
   test.equal(returned, true);
 });
 
-tape("variable.define does not terminate reachable generators", {html: "<div id=foo /><div id=baz />"}, async test => {
+tape("variable.define does not terminate reachable generators", async test => {
   let returned = false;
   const runtime = new Runtime();
   const main = runtime.module();
   const module = runtime.module();
   const bar = module.define("bar", [], function*() { try { while (true) yield 1; } finally { returned = true; }});
-  const baz = main.variable("#baz").define("baz", ["bar"], bar => bar);
-  const foo = main.variable("#foo").define("foo", ["bar"], bar => bar);
+  const baz = main.variable(true).define("baz", ["bar"], bar => bar);
+  const foo = main.variable(true).define("foo", ["bar"], bar => bar);
   main.variable().import("bar", module);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 1});
@@ -207,33 +207,33 @@ tape("variable.define does not terminate reachable generators", {html: "<div id=
   test.equal(returned, true);
 });
 
-tape("variable.define detects duplicate declarations", {html: "<div id=foo /><div id=bar /><div id=baz />"}, async test => {
+tape("variable.define detects duplicate declarations", async test => {
   const runtime = new Runtime();
   const main = runtime.module();
-  const v1 = main.variable("#foo").define("foo", [], () => 1);
-  const v2 = main.variable("#bar").define("foo", [], () => 2);
-  const v3 = main.variable("#baz").define(null, ["foo"], foo => foo);
+  const v1 = main.variable(true).define("foo", [], () => 1);
+  const v2 = main.variable(true).define("foo", [], () => 2);
+  const v3 = main.variable(true).define(null, ["foo"], foo => foo);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(v1), {error: "RuntimeError: foo is defined more than once"});
   test.deepEqual(await valueof(v2), {error: "RuntimeError: foo is defined more than once"});
   test.deepEqual(await valueof(v3), {error: "RuntimeError: foo could not be resolved"});
 });
 
-tape("variable.define detects missing inputs and erroneous inputs", {html: "<div id=foo /><div id=bar />"}, async test => {
+tape("variable.define detects missing inputs and erroneous inputs", async test => {
   const runtime = new Runtime();
   const main = runtime.module();
-  const v1 = main.variable("#foo").define("foo", ["baz"], () => 1);
-  const v2 = main.variable("#bar").define("bar", ["foo"], () => 2);
+  const v1 = main.variable(true).define("foo", ["baz"], () => 1);
+  const v2 = main.variable(true).define("bar", ["foo"], () => 2);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(v1), {error: "RuntimeError: baz is not defined"});
   test.deepEqual(await valueof(v2), {error: "RuntimeError: foo could not be resolved"});
 });
 
-tape("variable.define allows masking of builtins", {html: "<div id=foo />"}, async test => {
+tape("variable.define allows masking of builtins", async test => {
   const runtime = new Runtime({color: "red"});
   const main = runtime.module();
   const mask = main.define("color", "green");
-  const foo = main.variable("#foo").define(null, ["color"], color => color);
+  const foo = main.variable(true).define(null, ["color"], color => color);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: "green"});
   mask.delete();
@@ -241,19 +241,19 @@ tape("variable.define allows masking of builtins", {html: "<div id=foo />"}, asy
   test.deepEqual(await valueof(foo), {value: "red"});
 });
 
-tape("variable.define supports promises", {html: "<div id=foo />"}, async test => {
+tape("variable.define supports promises", async test => {
   const runtime = new Runtime();
   const main = runtime.module();
-  const foo = main.variable("#foo").define("foo", [], () => new Promise(resolve => setImmediate(() => resolve(42))));
+  const foo = main.variable(true).define("foo", [], () => new Promise(resolve => setImmediate(() => resolve(42))));
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 42});
 });
 
-tape("variable.define supports generator cells", {html: "<div id=foo />"}, async test => {
+tape("variable.define supports generator cells", async test => {
   let i = 0;
   const runtime = new Runtime();
   const main = runtime.module();
-  const foo = main.variable("#foo").define("foo", [], function*() { while (i < 3) yield ++i; });
+  const foo = main.variable(true).define("foo", [], function*() { while (i < 3) yield ++i; });
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 1});
   await new Promise(setImmediate);
@@ -262,11 +262,11 @@ tape("variable.define supports generator cells", {html: "<div id=foo />"}, async
   test.deepEqual(await valueof(foo), {value: 3});
 });
 
-tape("variable.define supports generator objects", {html: "<div id=foo />"}, async test => {
+tape("variable.define supports generator objects", async test => {
   function* range(n) { for (let i = 0; i < n; ++i) yield i; }
   const runtime = new Runtime();
   const main = runtime.module();
-  const foo = main.variable("#foo").define("foo", [], () => range(3));
+  const foo = main.variable(true).define("foo", [], () => range(3));
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 0});
   await new Promise(setImmediate);
@@ -275,11 +275,11 @@ tape("variable.define supports generator objects", {html: "<div id=foo />"}, asy
   test.deepEqual(await valueof(foo), {value: 2});
 });
 
-tape("variable.define supports a promise that resolves to a generator object", {html: "<div id=foo />"}, async test => {
+tape("variable.define supports a promise that resolves to a generator object", async test => {
   function* range(n) { for (let i = 0; i < n; ++i) yield i; }
   const runtime = new Runtime();
   const main = runtime.module();
-  const foo = main.variable("#foo").define("foo", [], async () => range(3));
+  const foo = main.variable(true).define("foo", [], async () => range(3));
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 0});
   await new Promise(setImmediate);
@@ -288,11 +288,11 @@ tape("variable.define supports a promise that resolves to a generator object", {
   test.deepEqual(await valueof(foo), {value: 2});
 });
 
-tape("variable.define supports generators that yield promises", {html: "<div id=foo />"}, async test => {
+tape("variable.define supports generators that yield promises", async test => {
   let i = 0;
   const runtime = new Runtime();
   const main = runtime.module();
-  const foo = main.variable("#foo").define("foo", [], function*() { while (i < 3) yield Promise.resolve(++i); });
+  const foo = main.variable(true).define("foo", [], function*() { while (i < 3) yield Promise.resolve(++i); });
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 1});
   await new Promise(setImmediate);
@@ -301,11 +301,11 @@ tape("variable.define supports generators that yield promises", {html: "<div id=
   test.deepEqual(await valueof(foo), {value: 3});
 });
 
-tape("variable.define allows a variable to be redefined", {html: "<div id=foo /><div id=bar />"}, async test => {
+tape("variable.define allows a variable to be redefined", async test => {
   const runtime = new Runtime();
   const main = runtime.module();
-  const foo = main.variable("#foo").define("foo", [], () => 1);
-  const bar = main.variable("#bar").define("bar", ["foo"], foo => new Promise(resolve => setImmediate(() => resolve(foo))));
+  const foo = main.variable(true).define("foo", [], () => 1);
+  const bar = main.variable(true).define("bar", ["foo"], foo => new Promise(resolve => setImmediate(() => resolve(foo))));
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 1});
   test.deepEqual(await valueof(bar), {value: 1});
@@ -315,10 +315,10 @@ tape("variable.define allows a variable to be redefined", {html: "<div id=foo />
   test.deepEqual(await valueof(bar), {value: 2});
 });
 
-tape("variable.define ignores an asynchronous result from a redefined variable", {html: "<div id=foo />"}, async test => {
+tape("variable.define ignores an asynchronous result from a redefined variable", async test => {
   const runtime = new Runtime();
   const main = runtime.module();
-  const foo = main.variable("#foo").define("foo", [], () => new Promise(resolve => setTimeout(() => resolve("fail"), 150)));
+  const foo = main.variable(true).define("foo", [], () => new Promise(resolve => setTimeout(() => resolve("fail"), 150)));
   await new Promise(setImmediate);
   foo.define("foo", [], () => "success");
   await new Promise(resolve => setTimeout(resolve, 250));
@@ -326,11 +326,11 @@ tape("variable.define ignores an asynchronous result from a redefined variable",
   test.deepEqual(foo._value, "success");
 });
 
-tape("variable.define ignores an asynchronous result from a redefined input", {html: "<div id=foo />"}, async test => {
+tape("variable.define ignores an asynchronous result from a redefined input", async test => {
   const runtime = new Runtime();
   const main = runtime.module();
   const bar = main.variable().define("bar", [], () => new Promise(resolve => setTimeout(() => resolve("fail"), 150)));
-  const foo = main.variable("#foo").define("foo", ["bar"], bar => bar);
+  const foo = main.variable(true).define("foo", ["bar"], bar => bar);
   await new Promise(setImmediate);
   bar.define("bar", [], () => "success");
   await new Promise(resolve => setTimeout(resolve, 250));
@@ -338,11 +338,11 @@ tape("variable.define ignores an asynchronous result from a redefined input", {h
   test.deepEqual(foo._value, "success");
 });
 
-tape("variable.define does not try to compute unreachable variables", {html: "<div id=foo /><div id=bar />"}, async test => {
+tape("variable.define does not try to compute unreachable variables", async test => {
   const runtime = new Runtime();
   const main = runtime.module();
   let evaluated = false;
-  const foo = main.variable("#foo").define("foo", [], () => 1);
+  const foo = main.variable(true).define("foo", [], () => 1);
   const bar = main.variable().define("bar", ["foo"], (foo) => evaluated = foo);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 1});
@@ -350,38 +350,38 @@ tape("variable.define does not try to compute unreachable variables", {html: "<d
   test.equals(evaluated, false);
 });
 
-tape("variable.define can reference whitelisted globals", {html: "<div id=foo />"}, async test => {
+tape("variable.define can reference whitelisted globals", async test => {
   const runtime = new Runtime(null, name => name === "magic" ? 21 : undefined);
   const module = runtime.module();
-  const foo = module.variable("#foo").define(["magic"], magic => magic * 2);
+  const foo = module.variable(true).define(["magic"], magic => magic * 2);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 42});
 });
 
-tape("variable.define captures the value of whitelisted globals", {html: "<div id=foo />"}, async test => {
+tape("variable.define captures the value of whitelisted globals", async test => {
   let magic = 0;
   const runtime = new Runtime(null, name => name === "magic" ? ++magic : undefined);
   const module = runtime.module();
-  const foo = module.variable("#foo").define(["magic"], magic => magic * 2);
+  const foo = module.variable(true).define(["magic"], magic => magic * 2);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 2});
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 2});
 });
 
-tape("variable.define can override whitelisted globals", {html: "<div id=foo />"}, async test => {
+tape("variable.define can override whitelisted globals", async test => {
   const runtime = new Runtime(null, name => name === "magic" ? 1 : undefined);
   const module = runtime.module();
   module.variable().define("magic", [], () => 2);
-  const foo = module.variable("#foo").define(["magic"], magic => magic * 2);
+  const foo = module.variable(true).define(["magic"], magic => magic * 2);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 4});
 });
 
-tape("variable.define can dynamically override whitelisted globals", {html: "<div id=foo />"}, async test => {
+tape("variable.define can dynamically override whitelisted globals", async test => {
   const runtime = new Runtime(null, name => name === "magic" ? 1 : undefined);
   const module = runtime.module();
-  const foo = module.variable("#foo").define(["magic"], magic => magic * 2);
+  const foo = module.variable(true).define(["magic"], magic => magic * 2);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 2});
   module.variable().define("magic", [], () => 2);
@@ -389,10 +389,10 @@ tape("variable.define can dynamically override whitelisted globals", {html: "<di
   test.deepEqual(await valueof(foo), {value: 4});
 });
 
-tape("variable.define cannot reference non-whitelisted globals", {html: "<div id=foo />"}, async test => {
+tape("variable.define cannot reference non-whitelisted globals", async test => {
   const runtime = new Runtime();
   const module = runtime.module();
-  const foo = module.variable("#foo").define(["magic"], magic => magic * 2);
+  const foo = module.variable(true).define(["magic"], magic => magic * 2);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {error: "RuntimeError: magic is not defined"});
 });

--- a/test/variable/delete-test.js
+++ b/test/variable/delete-test.js
@@ -2,11 +2,11 @@ import {Runtime} from "../../src/";
 import tape from "../tape";
 import valueof from "./valueof";
 
-tape("variable.delete allows a variable to be deleted", {html: "<div id=foo /><div id=bar />"}, async test => {
+tape("variable.delete allows a variable to be deleted", async test => {
   const runtime = new Runtime();
   const main = runtime.module();
-  const foo = main.variable("#foo").define("foo", [], () => 1);
-  const bar = main.variable("#bar").define("bar", ["foo"], foo => new Promise(resolve => setImmediate(() => resolve(foo))));
+  const foo = main.variable(true).define("foo", [], () => 1);
+  const bar = main.variable(true).define("bar", ["foo"], foo => new Promise(resolve => setImmediate(() => resolve(foo))));
   await new Promise(setImmediate);
   test.deepEqual(await valueof(foo), {value: 1});
   test.deepEqual(await valueof(bar), {value: 1});

--- a/test/variable/derive-test.js
+++ b/test/variable/derive-test.js
@@ -2,15 +2,15 @@ import {Runtime} from "../../src/";
 import tape from "../tape";
 import valueof from "./valueof";
 
-tape("module.derive(overrides, module) injects variables into a copied module", {html: "<div id=a /><div id=b /><div id=c /><div id=c1 />"}, async test => {
+tape("module.derive(overrides, module) injects variables into a copied module", async test => {
   const runtime = new Runtime();
   const module0 = runtime.module();
-  const a0 = module0.variable("#a").define("a", [], () => 1);
-  const b0 = module0.variable("#b").define("b", [], () => 2);
-  const c0 = module0.variable("#c").define("c", ["a", "b"], (a, b) => a + b);
+  const a0 = module0.variable(true).define("a", [], () => 1);
+  const b0 = module0.variable(true).define("b", [], () => 2);
+  const c0 = module0.variable(true).define("c", ["a", "b"], (a, b) => a + b);
   const module1 = runtime.module();
   const module1_0 = module0.derive([{name: "d", alias: "b"}], module1);
-  const c1 = module1_0.variable("#c1").define(null, ["c"], c => c);
+  const c1 = module1_0.variable(true).define(null, ["c"], c => c);
   const d1 = module1.define("d", [], () => 42);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(a0), {value: 1});

--- a/test/variable/import-test.js
+++ b/test/variable/import-test.js
@@ -2,24 +2,24 @@ import {Runtime} from "../../src/";
 import tape from "../tape";
 import valueof from "./valueof";
 
-tape("variable.import(name, module) imports a variable from another module", {html: "<div id=bar />"}, async test => {
+tape("variable.import(name, module) imports a variable from another module", async test => {
   const runtime = new Runtime();
   const main = runtime.module();
   const module = runtime.module();
   module.define("foo", [], () => 42);
   main.import("foo", module);
-  const bar = main.variable("#bar").define("bar", ["foo"], foo => `bar-${foo}`);
+  const bar = main.variable(true).define("bar", ["foo"], foo => `bar-${foo}`);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(bar), {value: "bar-42"});
 });
 
-tape("variable.import(name, alias, module) imports a variable from another module under an alias", {html: "<div id=bar />"}, async test => {
+tape("variable.import(name, alias, module) imports a variable from another module under an alias", async test => {
   const runtime = new Runtime();
   const main = runtime.module();
   const module = runtime.module();
   module.define("foo", [], () => 42);
   main.import("foo", "baz", module);
-  const bar = main.variable("#bar").define("bar", ["baz"], baz => `bar-${baz}`);
+  const bar = main.variable(true).define("bar", ["baz"], baz => `bar-${baz}`);
   await new Promise(setImmediate);
   test.deepEqual(await valueof(bar), {value: "bar-42"});
 });


### PR DESCRIPTION
Runtimes can now be constructed with a whitelist of implicit global names. For each name, a corresponding reference that would be otherwise unresolved is now implicitly resolved to an variable whose value is the global. Unlike “reserved” globals (references to which are not considered inputs), implicit globals are treated as inputs, and thus can be overridden with local variables.

I see two downsides with this approach:

1. The global value is captured at the time the referencing variable is defined. This means it’s not a good idea to reference globals that change over time (such as, I dunno, window.status?). Fortunately for all use cases I can think of, the globals we want to reference are immutable, such as Blob or ImageData.

2. Referencing an implicit global is less efficient than a reserved global: it requires creating an implicit variable and being passed through as an input. A more efficient approach would track potential global references separately, not treat them as inputs if they are global references, replacing them with inputs if they are masked by a local variable. But that’s not currently possible as it would involve changing the variable definition function, which needs to list the inputs (including global references) as arguments. But perhaps this is acceptable, or perhaps it would be better to consider more general optimizations to the runtime?

With this change in place, we could remove some reserved globals from notebook-compiler (such as restricting it to language built-ins such as Array, Infinity, isNaN, etc.), and define a larger set of implicit globals in notebook (that includes browser features such as fetch, File, FileList, etc.).